### PR TITLE
Re-adds the loadbearing coconut

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -10,6 +10,12 @@ admin.initializeApp();
 const db = admin.firestore();
 const Timestamp = admin.firestore.Timestamp;
 
+
+exports.helloWorld = functions.https.onRequest((req, res) => { // LOAD BEARING FUNC, DON'T REMOVE THIS:
+    res.send("Hello, World!");});                              // Removing this (while deprecated)
+                                                               // requires further work on the firebase side
+                                                               // such work isn't worth the effort right now.
+
 /**
  * Signup Function: Creates a user in Firebase Auth and stores their profile in Firestore
  */


### PR DESCRIPTION
We'd need to do more modification on the firebase console side to remove the function (surprising, whoops!)
We're rolling back this change from the recent notes PR, and everything should go back to nominal

![image](https://github.com/user-attachments/assets/91a316f3-b3cb-46a6-91fe-12170b0cd8f6)
